### PR TITLE
Update navncx.html

### DIFF
--- a/_includes/navncx.html
+++ b/_includes/navncx.html
@@ -19,10 +19,6 @@
                 <li class="nav-item" style="">
                     <a class="nav-link" href="/dsidev/releases.html">Releases</a>
                 </li>
-                <li class="nav-item" style="">
-                    <a class="nav-link" href="/dsi.html">Blog</a>
-                </li>
-
             </ul>
             <ul class="navbar-nav">
                 <li class="nav-item" style="">


### PR DESCRIPTION
Removes blog button from mobile navigation bar as it is no longer available in the desktop navbar, and no longer has any blog posts.