### PR TITLE
Fixed the blog date for write_sdmc.html

### DIFF
--- a/dsidev/release/write_sdmc.html
+++ b/dsidev/release/write_sdmc.html
@@ -2,7 +2,7 @@
 title: "AGING and WRITE SDMC-LNC"
 layout: release
 releaseslug: write_sdmc
-date: 2025/xx/xx
+date: 2025/04/19
 preview: /preview.jpeg
 ---
     <h1>AGING and WRITE SDMC-LNC</h1>


### PR DESCRIPTION
The release date in the releases index is stated as 2025/04/19 but was listed as 2025/xx/xx in "write_sdmc.html", changed it to the release's upload date on the releases index page.